### PR TITLE
Update migration_analytics-lab_guide.adoc

### DIFF
--- a/doc/migration_analytics-lab_guide.adoc
+++ b/doc/migration_analytics-lab_guide.adoc
@@ -284,6 +284,18 @@ Last login: Mon Aug 26 05:03:34 2019 from workstation.example.com
 
 **COMMON**
 
+. In order to use the new SSH tunnel now listening on port 3128 on your machine, your Firefox browser will need to be configured to use the tunnel as a proxy address.  Since this will re-direct ALL broswer activity through the lab proxy, if you are using Firefox for anything other than this lab it is recommended that you first create a new Firefox profile.  This will allow you to set a proxy address for the new profile which will not interfere with normal use of your browser and may prevent other issues with the lab.
++
+If using Linux, enter this command at the prompt, and follow the instructions:
++
+----
+firefox --new-instance --ProfileManager
+----
++
+- Be sure to uncheck "Use Selected Profile Without Asking At Startup" before launching the new profile.
+- Full instructions for creating a new profile are published here: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Multiple_profiles
+- You can use the same instructions to delete the profile later on when you have finished with the lab.
+
 . Now by configuring the browser to access proxy in `localhost` port `3128` for all protocols, we will be running it as if it was directly inside the environment, consuming the internal DNS names. Internal DNS names used the domain `example.com`. Configure the proxy, for this use case, following this example:
 +
 image::localhost_proxy_config.png[Localhost Proxy Config]


### PR DESCRIPTION
Added a recommendation and instructions for creating a separate Firefox profile for use with the SSH tunnel and Squid proxy.